### PR TITLE
chore(gh actions): update to node 16

### DIFF
--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -10,7 +10,7 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run Docker Build
         run: |
@@ -33,7 +33,7 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install modules
         run: yarn
@@ -60,7 +60,7 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install modules
         run: yarn


### PR DESCRIPTION
In your recent stream you received a warning that you were using Node v12. The docs for Checkout v3 from GitHub are [here](https://github.com/actions/checkout) and an article talking about updating from v2 to v3 because Node v12 has been deprecated is [here](https://blog.eidinger.info/why-and-how-to-adopt-actionscheckoutv3-in-your-github-action-workflow). Hope this helps.